### PR TITLE
CI: Fix warnings & deprecation messages in the workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,3 @@
 !vcpkg.json
 !ports
 !*/*.csproj
-

--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -2,7 +2,7 @@ name: Nudge
 
 on:
   workflow_run:
-    workflows: ["CodeQL"]
+    workflows: ["CI", "Build devcontainer image"]
     types: [completed]
     branches: [master]
 


### PR DESCRIPTION
What type of PR is this?
CI: Resolve deprecation & warning messages in workflows
Enable DependaBot for GitHub actions

What this PR does / why we need it:
Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). - more info in the [post](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)

Which issue(s) this PR fixes:
https://github.com/G-Research/gr-oss/issues/639

------------
#### Optional

Testing results
🟢 Nudge - https://github.com/gr-oss-devops/ParquetSharp/actions/runs/9029388412/job/24811639990